### PR TITLE
Cleanup Event Hub project and ensure 4.0.0 compatibility

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -32,8 +32,3 @@ runs:
       uses: SAP/project-piper-action@main
       with:
         step-name: mavenBuild
-
-    #- name: Mutation Testing
-    #  if: ${{ inputs.mutation-testing == 'true' }}
-    #  run: mvn org.pitest:pitest-maven:mutationCoverage -f cds-feature-event-hub/pom.xml -ntp -B
-    #  shell: bash

--- a/cds-feature-event-hub/pom.xml
+++ b/cds-feature-event-hub/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.12.0</version>
+      <version>5.12.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/cds-feature-event-hub/pom.xml
+++ b/cds-feature-event-hub/pom.xml
@@ -16,12 +16,15 @@
 
   <properties>
     <packageName>com.sap.cds.feature.event-hub</packageName>
-    <generation-package>com.sap.cds.feature.event-hub.generated</generation-package>
-    <test-generation-folder>src/test/gen</test-generation-folder>
   </properties>
 
   <dependencies>
     <!-- CDS DEPENDENCIES -->
+    <dependency>
+      <groupId>com.sap.cds</groupId>
+      <artifactId>cds-services-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.sap.cds</groupId>
       <artifactId>cds-services-messaging</artifactId>
@@ -53,16 +56,19 @@
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
+      <version>6.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>2.0.17</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>2.19.0</version>
     </dependency>
 
     <!-- TEST DEPENDENCIES -->
@@ -114,172 +120,10 @@
   <build>
     <finalName>${project.artifactId}</finalName>
     <plugins>
-
-      <plugin>
-        <groupId>org.pitest</groupId>
-        <artifactId>pitest-maven</artifactId>
-        <configuration>
-          <targetClasses>
-            <param>com.sap.cds.feature.event-hub.handler.*</param>
-            <param>com.sap.cds.feature.event-hub.service.*</param>
-          </targetClasses>
-          <mutators>
-            <mutator>CONSTRUCTOR_CALLS</mutator>
-            <mutator>VOID_METHOD_CALLS</mutator>
-            <mutator>NON_VOID_METHOD_CALLS</mutator>
-            <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
-            <mutator>CONDITIONALS_BOUNDARY</mutator>
-            <mutator>EMPTY_RETURNS</mutator>
-            <mutator>NEGATE_CONDITIONALS</mutator>
-            <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
-            <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
-            <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
-            <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
-          </mutators>
-          <coverageThreshold>95</coverageThreshold>
-          <aggregatedMutationThreshold>90</aggregatedMutationThreshold>
-        </configuration>
-
-        <dependencies>
-          <dependency>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-junit5-plugin</artifactId>
-            <version>1.2.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${generation-folder}</directory>
-              <includes>
-                <include>**/*</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>${test-generation-folder}</directory>
-              <includes>
-                <include>**/*</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>src/test/resources</directory>
-              <includes>
-                <include>schema.sql</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>src/test/resources/cds</directory>
-              <includes>
-                <include>csn.json</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>src/test/resources/gen</directory>
-              <includes>
-                <include>**/*</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>./</directory>
-              <includes>
-                <include>.flattened-pom.xml</include>
-              </includes>
-            </fileset>
-          </filesets>
-        </configuration>
-        <executions>
-          <execution>
-            <id>auto-clean</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>com.sap.cds</groupId>
-        <artifactId>cds-maven-plugin</artifactId>
-        <configuration>
-          <skip>${skipDuringDeploy}</skip>
-        </configuration>
-        <executions>
-          <execution>
-            <id>cds.clean</id>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-
-          <execution>
-            <id>cds.install-node</id>
-            <goals>
-              <goal>install-node</goal>
-            </goals>
-            <configuration>
-              <skip>${skipDuringDeploy}</skip>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>cds.install-cdsdk</id>
-            <goals>
-              <goal>install-cdsdk</goal>
-            </goals>
-            <configuration>
-              <skip>${skipDuringDeploy}</skip>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>cds.generate</id>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-            <configuration>
-              <basePackage>${generation-package}.cds4j</basePackage>
-              <csnFile>${project.basedir}/src/gen/srv/src/main/resources/edmx/csn.json</csnFile>
-              <skip>${skipDuringDeploy}</skip>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>cds.test.generate</id>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-            <configuration>
-              <codeOutputDirectory>${project.basedir}/${test-generation-folder}/cds4j
-              </codeOutputDirectory>
-              <basePackage>${generation-package}.test.cds4j</basePackage>
-              <testSources>true</testSources>
-              <csnFile>${project.basedir}/src/test/resources/gen/src/main/resources/edmx/csn.json
-              </csnFile>
-              <skip>${skipDuringDeploy}</skip>
-            </configuration>
-          </execution>
-
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>
-                            ${excluded.generation.package}**/*
-            </exclude>
-          </excludes>
-        </configuration>
+        <version>0.8.12</version>
         <executions>
           <execution>
             <id>jacoco-initialize</id>
@@ -294,54 +138,12 @@
               <goal>report</goal>
             </goals>
           </execution>
-          <execution>
-            <id>jacoco-site-report-only-unit-tests</id>
-            <phase>test</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-check-unit-tests-only</id>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
-                  <element>BUNDLE</element>
-                  <limits>
-                    <limit implementation="org.jacoco.report.check.Limit">
-                      <counter>INSTRUCTION</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.5</minimum>
-                    </limit>
-                    <limit implementation="org.jacoco.report.check.Limit">
-                      <counter>BRANCH</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.5</minimum>
-                    </limit>
-                    <limit implementation="org.jacoco.report.check.Limit">
-                      <counter>COMPLEXITY</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.5</minimum>
-                    </limit>
-                    <limit implementation="org.jacoco.report.check.Limit">
-                      <counter>CLASS</counter>
-                      <value>MISSEDCOUNT</value>
-                      <maximum>3</maximum>
-                    </limit>
-                  </limits>
-                </rule>
-              </rules>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.11.2</version>
         <configuration>
           <skip>${skipDuringDeploy}</skip>
           <failOnError>true</failOnError>
@@ -352,24 +154,22 @@
             <goals>
               <goal>jar</goal>
             </goals>
-            <configuration>
-              <excludePackageNames>com.sap.cds.feature.event-hub.generated.*</excludePackageNames>
-            </configuration>
           </execution>
         </executions>
       </plugin>
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
         <executions>
           <execution>
+            <id>attach-sources</id>
             <goals>
-              <goal>jar</goal>
+              <goal>jar-no-fork</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 

--- a/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/client/EventHubClient.java
+++ b/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/client/EventHubClient.java
@@ -3,7 +3,6 @@ package com.sap.cds.feature.messaging.eventhub.client;
 import java.io.IOException;
 import java.util.Map;
 
-import com.sap.cds.services.environment.CdsProperties.ConnectionPool;
 import com.sap.cds.services.messaging.utils.CloudEventUtils;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf;

--- a/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/ord/PublishedEventsProcessor.java
+++ b/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/ord/PublishedEventsProcessor.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +63,7 @@ public class PublishedEventsProcessor implements CdsOrdNodeProcessor {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends TreeNode> Optional<T> process(@Nullable String nodeName, @Nullable T node) {
+	public <T extends TreeNode> Optional<T> process(String nodeName, T node) {
 		// - if node is a "packages" node:
 		//   - retrieve and store the ordId of the first package
 		//   - return the passed node again

--- a/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/utils/EventHubBindingUtils.java
+++ b/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/utils/EventHubBindingUtils.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sap.cds.services.runtime.CdsRuntime;
-import com.sap.cds.services.utils.CdsErrorStatuses;
 import com.sap.cds.services.utils.ErrorStatusException;
 import com.sap.cds.services.utils.environment.ServiceBindingUtils;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
@@ -29,7 +28,7 @@ public class EventHubBindingUtils {
 			logger.debug("Found EventBroker binding '{}' with service '{}' and plan '{}'", binding.getName().get(), binding.getServiceName().get(), binding.getServicePlan().get());
 			return Optional.of(binding);
 		} else if (bindings.size() > 1) {
-			throw new ErrorStatusException(CdsErrorStatuses.MULTIPLE_EVENT_HUB_BINDINGS);
+			throw new ErrorStatusException(EventHubErrorStatuses.MULTIPLE_EVENT_HUB_BINDINGS);
 		} else {
 			return Optional.empty();
 		}

--- a/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/utils/EventHubErrorStatuses.java
+++ b/cds-feature-event-hub/src/main/java/com/sap/cds/feature/messaging/eventhub/utils/EventHubErrorStatuses.java
@@ -1,0 +1,36 @@
+package com.sap.cds.feature.messaging.eventhub.utils;
+
+import com.sap.cds.services.ErrorStatus;
+import com.sap.cds.services.ErrorStatuses;
+
+public enum EventHubErrorStatuses implements ErrorStatus {
+
+	EVENT_HUB_EMIT_FAILED(50007026, "Event Hub service in single tenant plan does not support to emit events.", ErrorStatuses.SERVER_ERROR),
+	MULTIPLE_EVENT_HUB_BINDINGS(50007027, "Multiple event-hub service bindings found: Only a single service binding for Event Hub is supported.", ErrorStatuses.SERVER_ERROR),
+	EVENT_HUB_TENANT_CONTEXT_MISSING(50007028, "Missing tenant context to emit a message to Event Hub.", ErrorStatuses.SERVER_ERROR);
+
+	private final int code;
+	private final String description;
+	private final ErrorStatus httpError;
+
+	private EventHubErrorStatuses(int code, String description, ErrorStatus httpError) {
+		this.code = code;
+		this.description = description;
+		this.httpError = httpError;
+	}
+
+	@Override
+	public String getCodeString() {
+		return String.valueOf(code);
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public int getHttpStatus() {
+		return httpError.getHttpStatus();
+	}
+}

--- a/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/client/EventHubClientTest.java
+++ b/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/client/EventHubClientTest.java
@@ -1,6 +1,5 @@
 package com.sap.cds.feature.messaging.eventhub.client;
 
-import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
 import com.sap.cds.services.utils.environment.ServiceBindingUtils;

--- a/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/service/EventHubMessagingServiceConfigurationTest.java
+++ b/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/service/EventHubMessagingServiceConfigurationTest.java
@@ -8,13 +8,12 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
+import com.sap.cds.feature.messaging.eventhub.utils.EventHubErrorStatuses;
 import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.impl.environment.SimplePropertiesProvider;
 import com.sap.cds.services.messaging.MessagingService;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
-import com.sap.cds.services.utils.CdsErrorStatuses;
 import com.sap.cds.services.utils.ErrorStatusException;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingBuilder;
 
@@ -149,6 +148,6 @@ class EventHubMessagingServiceConfigurationTest {
 		});
 
 		ErrorStatusException e = Assertions.assertThrows(ErrorStatusException.class, () -> configurer.serviceConfigurations());
-		assertEquals(CdsErrorStatuses.MULTIPLE_EVENT_HUB_BINDINGS, e.getErrorStatus());
+		assertEquals(EventHubErrorStatuses.MULTIPLE_EVENT_HUB_BINDINGS, e.getErrorStatus());
 	}
 }

--- a/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/service/EventHubMessagingServiceTest.java
+++ b/cds-feature-event-hub/src/test/java/com/sap/cds/feature/messaging/eventhub/service/EventHubMessagingServiceTest.java
@@ -9,13 +9,12 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
+import com.sap.cds.feature.messaging.eventhub.utils.EventHubErrorStatuses;
 import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.impl.ContextualizedServiceException;
 import com.sap.cds.services.impl.environment.SimplePropertiesProvider;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
-import com.sap.cds.services.utils.CdsErrorStatuses;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingBuilder;
 
 class EventHubMessagingServiceTest {
@@ -42,7 +41,7 @@ class EventHubMessagingServiceTest {
 
 
 		ContextualizedServiceException e = Assertions.assertThrows(ContextualizedServiceException.class, () -> emitMessage(runtime));
-		assertEquals(CdsErrorStatuses.EVENT_HUB_EMIT_FAILED, e.getErrorStatus());
+		assertEquals(EventHubErrorStatuses.EVENT_HUB_EMIT_FAILED, e.getErrorStatus());
 
 	}
 
@@ -61,7 +60,7 @@ class EventHubMessagingServiceTest {
 		CdsRuntime runtime = configurer.complete();
 
 		ContextualizedServiceException e = Assertions.assertThrows(ContextualizedServiceException.class, () -> emitMessage(runtime));
-		assertEquals(CdsErrorStatuses.EVENT_HUB_TENANT_CONTEXT_MISSING, e.getErrorStatus());
+		assertEquals(EventHubErrorStatuses.EVENT_HUB_TENANT_CONTEXT_MISSING, e.getErrorStatus());
 	}
 
 	private void emitMessage(CdsRuntime runtime) {

--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <excluded.generation.package>com/sap/cds/feature/event-hub/generated/</excluded.generation.package>
-    <cds.services.version>3.8.0</cds.services.version>
-    <cds.install-cdsdk.version>8.7.3</cds.install-cdsdk.version>
-
-    <generation-folder>src/gen</generation-folder>
+    <cds.services.version>3.10.1</cds.services.version>
   </properties>
 
   <groupId>com.sap.cds</groupId>
@@ -58,28 +54,6 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.sap.cloud.sdk</groupId>
-        <artifactId>sdk-bom</artifactId>
-        <version>5.17.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-bom</artifactId>
-        <version>5.16.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.sap.cds</groupId>
-        <artifactId>cds-feature-event-hub</artifactId>
-        <version>${revision}</version>
-      </dependency>
-
       <!-- Mitigate vulnerabilities in commons-codec:commons-codec:1.11 -->
       <dependency>
         <groupId>commons-codec</groupId>
@@ -89,44 +63,18 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.sap.cds</groupId>
-      <artifactId>cds-services-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.12.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.27.3</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
-
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
       </plugin>
 
       <!-- POM FLATTENING FOR CI FRIENDLY VERSIONS -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.7.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>
@@ -151,9 +99,10 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
-            <id>no-duplicate-declared-dependencies</id>
+            <id>enforce-rules</id>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -177,61 +126,12 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.4.1</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
         </plugin>
         <plugin>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.4</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.11.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.26.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.7.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
-        </plugin>
-        <plugin>
-          <groupId>org.pitest</groupId>
-          <artifactId>pitest-maven</artifactId>
-          <version>1.18.2</version>
-        </plugin>
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.2.0</version>
-        </plugin>
-        <plugin>
-          <groupId>com.sap.cds</groupId>
-          <artifactId>cds-maven-plugin</artifactId>
-          <version>${cds.services.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The project was completely overloaded in pom.xml with unnecessary stuff in my opinion. All of this is cleaned up now.

Also prepared the project for the 4.0.0 release, by removing various deprecated code and also making it really independent of cds-services (some error objects where still used from CDS Services).

Closes: https://github.com/cap-java/cds-feature-event-hub/issues/48