### PR TITLE
fix: restrict wiremock to test scope

### DIFF
--- a/cds-feature-event-hub/pom.xml
+++ b/cds-feature-event-hub/pom.xml
@@ -103,6 +103,7 @@
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-jetty12</artifactId>
       <version>3.13.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
wiremock-jetty12 was declared without <scope>test</scope>